### PR TITLE
refactoring email and subscriber resources

### DIFF
--- a/controllers/emailController.js
+++ b/controllers/emailController.js
@@ -1,0 +1,146 @@
+const mongoose = require("mongoose");
+
+const {
+  AppError,
+  STATUS
+} = require("../utils/appError");
+const {
+  TYPES,
+  getErrorMessage,
+  getSuccessMessage
+} = require("../utils/getMessage");
+const Email = require("../models/emailModel");
+const asyncWrapper = require("../middlewares/asyncWrapper");
+
+
+// get All ContactUs Emails (Protected Route)
+const getEmails = asyncWrapper(async (req, res, next) => {
+
+  const emails = await Email.find({});
+
+  res.json({
+    status: STATUS.SUCCESS,
+    message: getSuccessMessage(TYPES.RETRIVE, "emails"),
+    code: 200,
+    data: {
+      emails,
+    },
+  });
+});
+
+// Get Single ContactUs Email (Protected Route)
+const getEmailById = asyncWrapper(async (req, res, next) => {
+
+  const { id } = req.params;
+
+  if (!id) {
+    const error = AppError.create(STATUS.FAILED, getErrorMessage(TYPES.REQUIRED, "(id)"), 400);
+    return next(error);
+  }
+
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    const error = AppError.create(STATUS.FAILED, getErrorMessage(TYPES.INVALID, "Object id"), 400);
+    return next(error);
+  }
+
+  const email = await Email.findById(id);
+  if (!email) {
+    const error = AppError.create(
+      STATUS.FAILED,
+      getErrorMessage(TYPES.NOT_FOUND, "email"),
+      404
+    );
+    return next(error);
+  }
+
+  res.json({
+    status: STATUS.SUCCESS,
+    message: getSuccessMessage(TYPES.RETRIVE, "email"),
+    code: 200,
+    data: {
+      email,
+    },
+  });
+});
+
+const createEmail = asyncWrapper(async (req, res, next) => {
+
+  const {
+    name,
+    email,
+    phone,
+    details
+  } = req.body;
+
+  if (!name || !email || !phone || !details) {
+    const error = AppError.create(
+      STATUS.FAILED,
+      getErrorMessage(TYPES.REQUIRED, "(name, email, phone, details)"),
+      400
+    );
+    return next(error);
+  }
+
+  const regex = new RegExp(/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/);
+  if (!regex.test(email)) {
+    const error = AppError.create(STATUS.FAILED, getErrorMessage(TYPES.INVALID, 'email'), 400);
+    return next(error);
+  }
+
+  const newEmail = await Email.create({
+    name,
+    email,
+    phone,
+    details
+  });
+
+  res.json({
+    status: STATUS.SUCCESS,
+    message: getSuccessMessage(TYPES.ADDED, "email"),
+    code: 201,
+    data: {
+      newEmail,
+    },
+  });
+});
+
+// delete Single ContactUs Email (Protected Route)
+const deleteEmailById = asyncWrapper(async (req, res, next) => {
+
+  const { id } = req.params;
+
+  if (!id) {
+    const error = AppError.create(STATUS.FAILED, getErrorMessage(TYPES.REQUIRED, "(id)"), 400);
+    return next(error);
+  }
+
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    const error = AppError.create(STATUS.FAILED, getErrorMessage(TYPES.INVALID, "Object id"), 400);
+    return next(error);
+  }
+
+  const oldEmail = await Email.findById(id);
+  if (!oldEmail) {
+    const error = AppError.create(
+      STATUS.FAILED,
+      getErrorMessage(TYPES.NOT_FOUND, "email"),
+      404
+    );
+    return next(error);
+  }
+
+  await oldEmail.deleteOne();
+
+  res.json({
+    status: STATUS.SUCCESS,
+    message: getSuccessMessage(TYPES.DELETE, "email"),
+    code: 204
+  });
+});
+
+module.exports = {
+  getEmails,
+  getEmailById,
+  createEmail,
+  deleteEmailById
+}

--- a/controllers/publicController.js
+++ b/controllers/publicController.js
@@ -90,97 +90,10 @@ const updateAboutPage = asyncWrapper(async (req, res, next) => {
   });
 });
 
-// get All ContactUs Emails (Protected Route)
-const getContactUsEmails = asyncWrapper(async (req, res, next) => {
-  const Emails = await Email.find({});
-  if (!Emails) {
-    const error = AppError.create(
-      STATUS.FAILED,
-      getErrorMessage(TYPES.NOT_FOUND, "contactus emails")
-    );
-    return next(error);
-  }
-  res.json({
-    status: STATUS.SUCCESS,
-    message: getSuccessMessage(TYPES.RETRIVE, "contact us emails"),
-    data: {
-      Emails,
-    },
-  });
-});
 
-// Get Single ContactUs Email (Protected Route)
-const getContactUsEmailById = asyncWrapper(async (req, res, next) => {
-  const email = await Email.findById(req.params.id);
-  if (!email) {
-    const error = AppError.create(
-      STATUS.FAILED,
-      getErrorMessage(TYPES.NOT_FOUND, "contact us email")
-    );
-    return next(error);
-  }
-  res.json({
-    status: STATUS.SUCCESS,
-    message: getSuccessMessage(TYPES.RETRIVE, "contact us email"),
-    data: {
-      email,
-    },
-  });
-});
-
-const createContactUsEmail = asyncWrapper(async (req, res, next) => {
-  const { name, email, phone, details } = req.body;
-  if (!name || !email || !phone || !details) {
-    const error = AppError.create(
-      STATUS.FAILED,
-      getErrorMessage(TYPES.INVALID, "All fields are required")
-    );
-    return next(error);
-  }
-  if (await Email.findOne({ email: email })) {
-    const error = AppError.create(
-      STATUS.FAILED,
-      getErrorMessage(TYPES.INVALID, "Email already exists")
-    );
-    return next(error); // if email already exists, return an error and stop the process. 400 Bad Request status code is used here. 409 Conflict status code is also possible.
-  }
-  const newEmail = new Email({ name, email, phone, details });
-  await newEmail.save();
-
-  res.json({
-    status: STATUS.SUCCESS,
-    message: getSuccessMessage(TYPES.CREATE, "ContactUs"),
-    data: {
-      newEmail,
-    },
-  });
-});
-
-// delete Single ContactUs Email (Protected Route)
-const deleteContactUsEmailById = asyncWrapper(async (req, res, next) => {
-  const email = await Email.findByIdAndDelete(req.params.id);
-  if (!email) {
-    const error = AppError.create(
-      STATUS.FAILED,
-      getErrorMessage(TYPES.NOT_FOUND, "ContactUs Email ")
-    );
-    return next(error);
-  }
-  res.json({
-    status: STATUS.SUCCESS,
-    message: getSuccessMessage(TYPES.DELETE, "Contact-Us email"),
-    data: {
-      email,
-    },
-  });
-});
 module.exports = {
   getHomePage,
   updateHomePage,
   getAboutPage,
   updateAboutPage,
-  getContactUsEmails,
-  getContactUsEmailById,
-  createContactUsEmail,
-  deleteContactUsEmailById,
 };

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const authRouter = require("./routes/authRoutes");
 const fileRouter = require("./routes/fileRoutes");
 const eventRouter = require("./routes/eventRoutes");
 const publicRouter = require("./routes/publicRoutes");
-const subscribersRouter = require("./routes/subscriberRoutes");
+const subscriberRouter = require("./routes/subscriberRoutes");
+const emailRouter = require("./routes/emailRoutes");
 
 dotenv.config({ path: `${__dirname}/.env` });
 
@@ -21,16 +22,18 @@ app.use(express.urlencoded({ extended: true }));
 app.use(compression());
 
 app.use("/api/auth", authRouter);
+app.use("/api/public", publicRouter);
 app.use("/api/files", fileRouter);
 app.use("/api/events", eventRouter);
-app.use("/api/public", publicRouter);
-app.use("/api",subscribersRouter);
+app.use("/api/subscribers", subscriberRouter);
+app.use("/api/emails", emailRouter);
 
 app.get("/", (req, res) => {
   res.status(200).send("TECHTALENT SERVER!");
 });
 
 app.use((error, req, res, next) => {
+
   res.status(error.statusCode || 500).json({
     status: error.statusText || STATUS.ERROR,
     message: error.message,

--- a/models/emailModel.js
+++ b/models/emailModel.js
@@ -1,6 +1,6 @@
 const mongoose = require("mongoose");
 
-const EmailScheme = new mongoose.Schema({
+const emailSchema = new mongoose.Schema({
   name: {
     type: String,
     required: [true, "Name is required!"]
@@ -19,6 +19,6 @@ const EmailScheme = new mongoose.Schema({
   },
 });
 
-const Email = mongoose.model("Email", EmailScheme);
+const Email = mongoose.model("Email", emailSchema);
 
 module.exports = Email;

--- a/models/subscriberModel.js
+++ b/models/subscriberModel.js
@@ -1,12 +1,12 @@
 const mongoose = require("mongoose");
 
-const SubscriberScheme = new mongoose.Schema({
+const subscriberSchema = new mongoose.Schema({
   email: {
     type: String,
     required: [true, "Email is required!"],
   },
 });
 
-const Subscriber = mongoose.model("Subscriber", SubscriberScheme);
+const Subscriber = mongoose.model("Subscriber", subscriberSchema);
 
 module.exports = Subscriber;

--- a/routes/emailRoutes.js
+++ b/routes/emailRoutes.js
@@ -1,0 +1,24 @@
+const express = require("express");
+
+const {
+  createEmail,
+  deleteEmailById,
+  getEmailById,
+  getEmails
+} = require("../controllers/emailController");
+const verifyToken = require("../middlewares/verifyToken");
+const allowedTo = require("../middlewares/allowedTo");
+const ROLES = require("../utils/roles");
+
+const router = express.Router();
+
+
+router.route("/")
+  .get(verifyToken, allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN), getEmails)
+  .post(createEmail);
+
+router.route("/:id")
+  .get(verifyToken, allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN), getEmailById)
+  .delete(verifyToken, allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN), deleteEmailById);
+
+module.exports = router;

--- a/routes/publicRoutes.js
+++ b/routes/publicRoutes.js
@@ -5,10 +5,6 @@ const {
   updateAboutPage,
   getHomePage,
   updateHomePage,
-  getContactUsEmails,
-  getContactUsEmailById,
-  createContactUsEmail,
-  deleteContactUsEmailById,
 } = require("../controllers/publicController");
 const verifyToken = require("../middlewares/verifyToken");
 const allowedTo = require("../middlewares/allowedTo");
@@ -26,24 +22,4 @@ router
   .get(getAboutPage)
   .put(verifyToken, allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN), updateAboutPage);
 
-router
-  .route("/contact-us/emails")
-  .get(
-    verifyToken,
-    allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN),
-    getContactUsEmails
-  )
-  .post(createContactUsEmail);
-router
-  .route("/contact-us/emails/:id")
-  .get(
-    verifyToken,
-    allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN),
-    getContactUsEmailById
-  )
-  .delete(
-    verifyToken,
-    allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN),
-    deleteContactUsEmailById
-  );
 module.exports = router;

--- a/routes/subscriberRoutes.js
+++ b/routes/subscriberRoutes.js
@@ -1,34 +1,22 @@
-const express = require("express");
-const verifyToken = require("../middlewares/verifyToken");
-const allowedTo = require("../middlewares/allowedTo");
-const ROLES = require("../utils/roles");
 const {
-  addSubscriber,
+  createSubscriber,
   getAllSubscribers,
   deleteSubscriberById,
   getSubscriberById,
 } = require("../controllers/subscriberModel");
+const express = require("express");
+const verifyToken = require("../middlewares/verifyToken");
+const allowedTo = require("../middlewares/allowedTo");
+const ROLES = require("../utils/roles");
 
 const router = express.Router();
 
-router
-  .route("/subscriber")
-  .get(
-    verifyToken,
-    allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN),
-    getAllSubscribers
-  ).post(addSubscriber);
-router
-  .route("/subscriber/:id")
-  .get(
-    verifyToken,
-    allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN),
-    getSubscriberById
-  )
-  .delete(
-    verifyToken,
-    allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN),
-    deleteSubscriberById
-  );
+router.route("/")
+  .get(verifyToken, allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN), getAllSubscribers)
+  .post(createSubscriber);
+
+router.route("/:id")
+  .get(verifyToken, allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN), getSubscriberById)
+  .delete(verifyToken, allowedTo(ROLES.ADMIN, ROLES.SUPER_ADMIN), deleteSubscriberById);
 
 module.exports = router;

--- a/utils/getMessage.js
+++ b/utils/getMessage.js
@@ -14,7 +14,8 @@ const TYPES = {
   AUTHENTICATE: 'authenticate',
   AUTHORIZE: 'authorize',
   LOGGED_OUT: 'logged out',
-  SEND: 'send'
+  SEND: 'send',
+  SUBSCRIBE: 'subscribe'
 };
 
 const getErrorMessage = (type, field) => {
@@ -55,6 +56,10 @@ const getErrorMessage = (type, field) => {
 
     case TYPES.AUTHORIZE:
       message = `Permission denied. You do not have access to this resource!`;
+      break;
+
+    case TYPES.SUBSCRIBE:
+      message = `The email ${field} already subscribed!`;
       break;
   }
 


### PR DESCRIPTION
> ### Description :-

#### :heavy_check_mark:  Separate Concerns of `email` and `subscriber`  entities : :point_down: 

I noticed that @AbdoOsary0 creating the `email` handlers inside the `publicController.js` 
that's wrong cause of the concens of the `Email` which is an entity not just schema to be used as 
a replacement type.
I fixed the problem by separating the email handler inside `emailController.js` that represents the `Email` 
resource.
Also the some problem occured for the `publicRoutes.js` which was contain all endpoints of the `Email`
resource. I fixed it by creating `emailRoutes.js` and copying the email handlers inside it.
The same problem goes to the `S6ubscriber` model but with some updates in the `appError.js`